### PR TITLE
Add typescript definition file

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git"
   },
   "main": "dist/vue-content-loader.cjs.js",
-  "types": "src/vue-content-loader.d.ts"
+  "types": "src/vue-content-loader.d.ts",
   "module": "dist/vue-content-loader.es.js",
   "cdn": "dist/vue-content-loader.min.js",
   "unpkg": "dist/vue-content-loader.min.js",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git"
   },
   "main": "dist/vue-content-loader.cjs.js",
+  "types": "src/vue-content-loader.d.ts"
   "module": "dist/vue-content-loader.es.js",
   "cdn": "dist/vue-content-loader.min.js",
   "unpkg": "dist/vue-content-loader.min.js",

--- a/src/vue-content-loader.d.ts
+++ b/src/vue-content-loader.d.ts
@@ -1,0 +1,29 @@
+import { VueConstructor } from 'vue';
+
+export const ContentLoader: ContentLoaderConstructor
+export const FacebookLoader: FacebookLoaderConstructor
+export const BulletListLoader: BulletListLoaderConstructor
+export const InstagramLoader: InstagramLoaderConstructor
+export const CodeLoader: CodeLoaderConstructor
+export const ListLoader: ListLoaderConstructor
+
+export interface ContentLoaderProps {
+  width: number,
+  height: number,
+  speed: number,
+  preserveAspectRatio: string,
+  primaryColor: string,
+  secondaryColor: string,
+  uniqueKey: string,
+  animate: boolean
+}
+
+export interface ContentLoaderConstructor extends VueConstructor {
+  props: ContentLoaderProps
+}
+
+export interface FacebookLoaderConstructor extends ContentLoaderConstructor{}
+export interface CodeLoaderConstructor extends ContentLoaderConstructor{}
+export interface BulletListLoaderConstructor extends ContentLoaderConstructor{}
+export interface InstagramLoaderConstructor extends ContentLoaderConstructor{}
+export interface ListLoaderConstructor extends ContentLoaderConstructor{}


### PR DESCRIPTION
I was using this library for a personal app and I needed a typescript definition file so here it is!

Since it's a small code base and there is not much properties going on, every vue properties are declared for `ContentLoader` and the other definitions are just extending `ContentLoaderConstructor`.

Already tested on my local source code, need to be tested before merged though (first time I'm doing a .d.ts file for a particular module).

Should solve #11 