### PR TITLE
add baseUrl to contentLoader

### DIFF
--- a/src/ContentLoader.js
+++ b/src/ContentLoader.js
@@ -36,6 +36,9 @@ export default {
     animate: {
       type: Boolean,
       default: true
+    },
+    baseUrl: {
+      type: String
     }
   },
 
@@ -51,8 +54,8 @@ export default {
         preserveAspectRatio={props.preserveAspectRatio}
       >
         <rect
-          style={{ fill: `url(#${idGradient})` }}
-          clip-path={`url(#${idClip})`}
+          style={{ fill: `url(${baseUrl}#${idGradient})` }}
+          clipPath={`url(${baseUrl}#${idClip})`}
           x="0"
           y="0"
           width={props.width}


### PR DESCRIPTION
Safari doesn't display the gradient on website that have <base href="/"> in head. (vues SPA for example).
To resolve that it's necessary to add a baseUrl props and refers to it. 