### PR TITLE
Add baseUrl props for Safari bug 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9.10.1
     branches:
       ignore:
         - gh-pages # list of branches to ignore

--- a/src/ContentLoader.js
+++ b/src/ContentLoader.js
@@ -36,6 +36,9 @@ export default {
     animate: {
       type: Boolean,
       default: true
+    },
+    baseUrl: {
+      type: String
     }
   },
 
@@ -51,8 +54,8 @@ export default {
         preserveAspectRatio={props.preserveAspectRatio}
       >
         <rect
-          style={{ fill: `url(#${idGradient})` }}
-          clip-path={`url(#${idClip})`}
+          style={{ fill: `url(${baseUrl}#${idGradient})` }}
+          clipPath={`url(${baseUrl}#${idClip})`}
           x="0"
           y="0"
           width={props.width}


### PR DESCRIPTION
In Safari, svg could not be rendered because of <base href> tag on head (some SPA add this tag). Adding a props baseUrl (like the react-lib) to force the url